### PR TITLE
add configurable

### DIFF
--- a/Sources/Droplet+Configurable.swift
+++ b/Sources/Droplet+Configurable.swift
@@ -1,0 +1,40 @@
+import Vapor
+import Fluent
+
+extension Droplet {
+    /// Adds Driver to the Droplet the `fluent.json` specifies it.
+    public func addConfigurable(driver: Driver, name: String) {
+        if config["fluent", "driver"]?.string == name {
+            set(driver)
+            self.log.debug("Using database driver '\(name)'.")
+        } else {
+            self.log.debug("Not using database driver '\(name)'.")
+        }
+    }
+
+    /// Adds a ConfigInitializable Driver type to the Droplet if
+    /// the `fluent.json` specifies it.
+    public func addConfigurable<D: Driver & ConfigInitializable>(driver: D.Type, name: String) {
+        do {
+            if config["fluent", "driver"]?.string == name {
+                let driver = try driver.init(config: config)
+                set(driver)
+                self.log.debug("Using database driver '\(name)'.")
+            } else {
+                self.log.debug("Not using database driver '\(name)'.")
+            }
+        } catch {
+            self.log.warning("Could not configure database driver '\(name)': \(error)")
+        }
+    }
+
+    /// Sets the driver to this Droplet by
+    /// creating a Database.
+    private func set(_ driver: Driver) {
+        if let maxConnections = config["fluent", "maxConnections"]?.int {
+            self.database = Database(driver, maxConnections: maxConnections)
+        } else {
+            self.database = Database(driver)
+        }
+    }
+}

--- a/Sources/Droplet+Configurable.swift
+++ b/Sources/Droplet+Configurable.swift
@@ -31,6 +31,10 @@ extension Droplet {
     /// Sets the driver to this Droplet by
     /// creating a Database.
     private func set(_ driver: Driver) {
+        if let existing = self.database?.driver {
+            log.warning("overwriting existing driver \(existing) with \(driver)")
+        }
+
         if let maxConnections = config["fluent", "maxConnections"]?.int {
             self.database = Database(driver, maxConnections: maxConnections)
         } else {

--- a/Sources/Model.swift
+++ b/Sources/Model.swift
@@ -20,13 +20,10 @@ extension Model {
 }
 
 // MARK: StringInitializable
-extension Entity {
+extension StringInitializable where Self: Entity {
     public init?(from string: String) throws {
-        // FIXME: hacky
-        let node = try Self.query().filter(Self.idKey, .equals, string).raw()
-        if case .array(let array) = node, let first = array.first {
-            try self.init(node: first)
-            id = first[Self.idKey]
+        if let model = try Self.find(string) {
+            self = model
         } else {
             return nil
         }

--- a/Tests/VaporFluentTests/VaporFluentTests.swift
+++ b/Tests/VaporFluentTests/VaporFluentTests.swift
@@ -3,9 +3,7 @@ import XCTest
 
 class VaporFluentTests: XCTestCase {
     func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-//        XCTAssertEqual(FluentVapor().text, "Hello, World!")
+        XCTAssertEqual(2 + 2, 4)
     }
 
 


### PR DESCRIPTION
Adds `addConfigurable` methods for driver like other Droplet configurable properties.

These methods look most similar to the `LogProtocol` in that they support passing either an initialized driver or a `ConfigInitializable` one: https://github.com/vapor/vapor/blob/master/Sources/Vapor/Droplet/Droplet%2BConfigurable.swift#L37

And the add call here: https://github.com/vapor/vapor/blob/master/Sources/Vapor/Droplet/Droplet.swift#L286

I think allowing these `addConfigurable` methods to throw instead of logging could be a future improvement. This would require the `provider.boot` method to be able to throw. 
