### PR TITLE
configurable query logging

### DIFF
--- a/Sources/FluentProvider/Provider.swift
+++ b/Sources/FluentProvider/Provider.swift
@@ -183,8 +183,8 @@ public final class Provider: Vapor.Provider {
         }
 
         if self.log == true {
-            database.log = { query in
-                drop.log.info(query.description)
+            database.log = { [weak drop] query in
+                drop?.log.info(query.description)
             }
         }
         

--- a/Sources/FluentProvider/Provider.swift
+++ b/Sources/FluentProvider/Provider.swift
@@ -44,6 +44,9 @@ public final class Provider: Vapor.Provider {
     /// be added by Fluent
     public let autoForeignKeys: Bool?
 
+    /// If true, queries will be logged.
+    public let log: Bool?
+
     public init(
         idKey: String? = nil,
         idType: IdentifierType? = nil,
@@ -52,7 +55,8 @@ public final class Provider: Vapor.Provider {
         defaultPageSize: Int? = nil,
         migrationEntityName: String? = nil,
         pivotNameConnector: String? = nil,
-        autoForeignKeys: Bool? = nil
+        autoForeignKeys: Bool? = nil,
+        log: Bool? = nil
     ) {
         self.idKey = idKey
         self.idType = idType
@@ -62,6 +66,7 @@ public final class Provider: Vapor.Provider {
         self.migrationEntityName = migrationEntityName
         self.pivotNameConnector = pivotNameConnector
         self.autoForeignKeys = autoForeignKeys
+        self.log = log
     }
 
     public init(config: Config) throws {
@@ -115,6 +120,7 @@ public final class Provider: Vapor.Provider {
         self.migrationEntityName = fluent["migrationEntityName"]?.string
         self.pivotNameConnector = fluent["pivotNameConnector"]?.string
         self.autoForeignKeys = fluent["autoForeignKeys"]?.bool
+        self.log = fluent["log"]?.bool
 
         // make sure they have specified a fluent.driver
         // to help avoid confusing `noDatabase` errors.
@@ -174,6 +180,12 @@ public final class Provider: Vapor.Provider {
         
         if let idKey = self.idKey {
             database.idKey = idKey
+        }
+
+        if self.log == true {
+            database.log = { query in
+                drop.log.info(query.description)
+            }
         }
         
         if let keyNamingConvention = self.keyNamingConvention {


### PR DESCRIPTION
Instead of doing:

```swift
drop.database.log = { query in
    print(query)
}
```

you can now do

`Config/fluent.json`
```swift
{
    ...,
    "log": true
    ...
}
```

This is a little bit easier and has the added benefit of allowing logging to be enabled _before_ preparations run.

The old syntax will continue to work.

- Adds a new configuration option `"log": true` in `fluent.json` for enabling query logging.
- Fixes https://github.com/vapor/fluent-provider/issues/24