### PR TITLE
Updating the version shield to show Swift 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@
         <img src="https://circleci.com/gh/vapor/fluent-provider.svg?style=shield" alt="Continuous Integration">
     </a>
     <a href="https://swift.org">
-        <img src="http://img.shields.io/badge/swift-3.1-brightgreen.svg" alt="Swift 4">
+        <img src="http://img.shields.io/badge/swift-4-brightgreen.svg" alt="Swift 4">
     </a>
 </p>


### PR DESCRIPTION
The alt text has already been updated, but not the URL.