### PR TITLE
Add Config setting for skipping preparations

### DIFF
--- a/Sources/FluentProvider/Provider.swift
+++ b/Sources/FluentProvider/Provider.swift
@@ -118,22 +118,22 @@ public final class Provider: Vapor.Provider {
         } else {
             keyNamingConvention = nil
         }
-
+        
+        var shouldSkipPreparationsByDefault: Bool = false
 
         self.defaultPageKey = fluent["defaultPageKey"]?.string
         self.defaultPageSize = fluent["defaultPageSize"]?.int
         if let name = fluent["migrationEntityName"] {
             if name.isNull {
                 self.migrationEntityName = nil
-                self.skipPreparations = true
+                shouldSkipPreparationsByDefault = true
             } else {
                 self.migrationEntityName = name.string
-                self.skipPreparations = false
             }
         } else {
             self.migrationEntityName = nil
-            self.skipPreparations = false
         }
+        self.skipPreparations = fluent["skipPreparations"]?.bool ?? shouldSkipPreparationsByDefault
         self.pivotNameConnector = fluent["pivotNameConnector"]?.string
         self.autoForeignKeys = fluent["autoForeignKeys"]?.bool
         self.log = fluent["log"]?.bool

--- a/Tests/FluentProviderTests/CacheTests.swift
+++ b/Tests/FluentProviderTests/CacheTests.swift
@@ -78,7 +78,7 @@ class CacheTests: XCTestCase {
 
         do {
             try drop.cache.set("foo", "bar")
-            XCTFail("Should not have set properly")
+            XCTFail("Should not have set property")
         } catch SQLite.SQLiteError.prepare {
             // pass
             // a sqlite prepare error should be thrown

--- a/Tests/FluentProviderTests/CacheTests.swift
+++ b/Tests/FluentProviderTests/CacheTests.swift
@@ -87,8 +87,44 @@ class CacheTests: XCTestCase {
     }
 
 
+    func testExplicitSkipPreparations() throws {
+        // config specifying memory database
+        var config = try Config(arguments: ["vapor", "serve", "--port=8833", "--env=debug"])
+        try config.set("fluent.driver", "memory")
+        try config.set("droplet.cache", "fluent")
+        try config.set("fluent.migrationEntityName", "fluent")
+        try config.set("fluent.skipPreparations", true)
+        try config.addProvider(FluentProvider.Provider.self)
+
+        // add the entity for storing fluent caches
+        config.preparations.append(FluentCache.CacheEntity.self)
+
+        // create droplet with Fluent provider
+        let drop = try Droplet(config)
+
+        // run the droplet
+        background {
+            try! drop.run()
+        }
+        drop.console.wait(seconds: 1)
+
+        // test cache
+        XCTAssert(drop.cache is FluentCache)
+
+        do {
+            try drop.cache.set("foo", "bar")
+            XCTFail("Should not have set property")
+        } catch StatusError.error(let s) where s.starts(with: "no such table") {
+            // pass
+            // a sqlite prepare error should be thrown
+            // since preparations were skipped
+        }
+    }
+
+
     static var allTests = [
         ("testHappyPath", testHappyPath),
         ("testSkipPreparations", testSkipPreparations),
+        ("testExplicitSkipPreparations", testExplicitSkipPreparations)
     ]
 }

--- a/Tests/FluentProviderTests/CacheTests.swift
+++ b/Tests/FluentProviderTests/CacheTests.swift
@@ -79,7 +79,7 @@ class CacheTests: XCTestCase {
         do {
             try drop.cache.set("foo", "bar")
             XCTFail("Should not have set property")
-        } catch SQLite.SQLiteError.prepare {
+        } catch StatusError.error(let s) where s.starts(with: "no such table") {
             // pass
             // a sqlite prepare error should be thrown
             // since preparations were skipped


### PR DESCRIPTION
Also incidentally fixes the `CacheTests` to work with the latest version of the `SQLite` module.

This PR definitely doesn't apply to the `beta` branch, but the migration entity name config seems to have vanished from that branch and I'm not sure it's appropriate to add this config setting there versus something else.